### PR TITLE
debugging '--psm' syntax for tesseract 4

### DIFF
--- a/passporteye/util/ocr.py
+++ b/passporteye/util/ocr.py
@@ -27,7 +27,7 @@ def ocr(img, mrz_mode=True):
         imsave(input_file_name, img)
 
         if mrz_mode:
-            config = "-psm 6 -c tessedit_char_whitelist=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789>< -c load_system_dawg=F -c load_freq_dawg=F"
+            config = "--psm 6 -c tessedit_char_whitelist=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789>< -c load_system_dawg=F -c load_freq_dawg=F"
         else:
             config = None
 


### PR DESCRIPTION
Otherwise returns 

pytesseract.pytesseract.TesseractError: (1, "Error, unknown command line argument '-psm'")

For tesseract version (macOS 10.13.5):

tesseract 4.0.0-beta.1-370-g8b64
 leptonica-1.75.3
  libjpeg 9c : libpng 1.6.34 : libtiff 4.0.9 : zlib 1.2.11 : libwebp 0.6.1 : libopenjp2 2.3.0