### PR TITLE
feat: add command to only extract the candidate ROIs

### DIFF
--- a/passporteye/mrz/text.py
+++ b/passporteye/mrz/text.py
@@ -9,6 +9,7 @@ License: MIT
 from collections import OrderedDict
 from datetime import datetime
 
+
 class MRZ(object):
     """
     A simple parser for a Type1 or Type3 Machine-readable zone strings from identification documents.
@@ -101,6 +102,7 @@ class MRZ(object):
     >>> assert m.valid and m.names == 'ISOLDE' and m.surname == 'MUSTERFRAU'
 
     """
+
     def __init__(self, mrz_lines):
         """
         Parse a TD1/TD2/TD3/MRVA/MRVB MRZ from a single newline-separated string or a list of strings.
@@ -110,7 +112,6 @@ class MRZ(object):
         """
         self._parse(mrz_lines)
         self.aux = {}
-
 
     @staticmethod
     def from_ocr(mrz_ocr_string):
@@ -191,6 +192,7 @@ class MRZ(object):
         result = OrderedDict()
         result['mrz_type'] = self.mrz_type
         result['valid_score'] = self.valid_score
+        result['raw_text'] = self.aux['text']
         if self.mrz_type is not None:
             result['type'] = self.type
             result['country'] = self.country
@@ -265,7 +267,6 @@ class MRZ(object):
         self.valid_number, self.valid_date_of_birth, self.valid_expiration_date, self.valid_composite = self.valid_check_digits
         return self.valid_score == 100
 
-
     def _parse_td2(self, a, b):
         len_a, len_b = len(a), len(b)
         if len(a) < 36:
@@ -300,7 +301,6 @@ class MRZ(object):
         self.valid_score = 100*self.valid_score//(40+2+1+1)
         self.valid_number, self.valid_date_of_birth, self.valid_expiration_date, self.valid_composite = self.valid_check_digits
         return self.valid_score == 100
-
 
     def _parse_td3(self, a, b):
         len_a, len_b = len(a), len(b)

--- a/passporteye/util/geometry.py
+++ b/passporteye/util/geometry.py
@@ -4,6 +4,7 @@ PassportEye::Util: Geometry & math utilities
 Author: Konstantin Tretyakov
 License: MIT
 '''
+from collections import OrderedDict
 import numpy as np
 from sklearn.decomposition import PCA
 from matplotlib import pyplot as plt
@@ -184,6 +185,18 @@ class RotatedBox(object):
         # fit output image in new shape
         return ((cols - out_cols) / 2., (rows - out_rows) / 2.)
 
+
+    def to_dict(self):
+        """Converts this object to an (ordered) dictionary of field-value pairs.
+        """
+
+        result = OrderedDict()
+        result["center"] = self.center
+        result["width"] = self.width
+        result["height"] = self.height
+        result["angle"] = self.angle
+        result["points"] = self.points
+        return result
 
     @staticmethod
     def from_points(points, box_type='bb'):


### PR DESCRIPTION
Basically, i'm using PassportEye to just extract the ROIs, and then running tesseract in node.js using tesseract.js to extract the text and parse the MRZ.

empty line changes introduced by autopep8

the `to_dict` for `Geometry` was because i was first considering just returning json for the boxes to extract, and then processing the image in node.js too, but it's simpler to just use your existing code to extract the boxes, as the prominent node.js image manipulation libraries are oriented towards web application use cases and not heavy ML/image processing stuff as scikit-image is. It can be removed as needed (idk if it works for `toJSON`ing anyways.)